### PR TITLE
Fix build and add CI

### DIFF
--- a/.github/workflows/lean.yml
+++ b/.github/workflows/lean.yml
@@ -1,0 +1,36 @@
+on:
+  push:
+  pull_request:
+
+name: build lean
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - name: install elan
+      run: |
+        set -o pipefail
+        curl -sSfL https://github.com/leanprover/elan/releases/download/v3.1.1/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
+        ./elan-init -y --default-toolchain none
+        echo "$HOME/.elan/bin" >> $GITHUB_PATH
+
+    - uses: actions/checkout@v3
+    - name: Set up olean cache
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache
+        key: oleans
+
+    - name: Configure
+      run: |
+        lake exe cache get
+
+    - name: Build
+      run: |
+        lake build
+
+    - name: Save olean cache
+      run: |
+        lake exe cache pack

--- a/LeanSrc.lean
+++ b/LeanSrc.lean
@@ -1,3 +1,0 @@
--- This module serves as the root of the `LeanSrc` library.
--- Import modules here that should be built as part of the library.
-import «LeanSrc».Basic

--- a/LeanSrc/Definitions.lean
+++ b/LeanSrc/Definitions.lean
@@ -1,4 +1,4 @@
-import mathlib
+import Mathlib
 
 
 -- We'll just use Lean's Nat

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -13,4 +13,4 @@ require mathlib from git
 
 @[default_target]
 lean_lib «LeanSrc» where
-  -- add any library configuration options here
+  globs := #[.submodules `LeanSrc]


### PR DESCRIPTION
The `LeanSrc.lean` file didn't actually import the other files, so `lake build` didn't build them.
Instead of fixing this, just delete `LeanSrc.lean` and teach `lake` to build all the files in the folder.

Doing this identifies an `import` that is invalid.

This adds configuration for GitHub actions to ensure that the code actually builds.